### PR TITLE
fix offline leaderboard crash

### DIFF
--- a/app/src/main/java/ch/epfl/sweng/rps/ui/leaderboard/LeaderboardFragment.kt
+++ b/app/src/main/java/ch/epfl/sweng/rps/ui/leaderboard/LeaderboardFragment.kt
@@ -81,9 +81,11 @@ class LeaderboardFragment : Fragment() {
 
 
     private fun loadPlayersUI(itemView: View, players: List<LeaderBoardInfo>) {
-        val champions = players.take(3)
-        showPlayersPosition(itemView, players)
-        showChampions(itemView, champions)
+        if(players.size > 3) {
+            val champions = players.take(3)
+            showPlayersPosition(itemView, players)
+            showChampions(itemView, champions)
+        }
 
     }
 


### PR DESCRIPTION
I found the crash reason is, that in offline mode, we have an empty player list, and I want to access the player avatar of the top 3, which will be out of the boundary.